### PR TITLE
Use NodeJS 16.x for building

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ installTheme(){
     mv resources/scripts/components/server/console/Console.tsx /var/www/pterodactyl/resources/scripts/components/server/console/Console.tsx
     cd /var/www/pterodactyl
 
-    curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+    curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
     apt update
     apt install -y nodejs
 


### PR DESCRIPTION
NodeJS 14 is now being deprecated in favour of 16.x with Pterodactyl Panel. It is recommended to update as this version of Node may not work with future builds.